### PR TITLE
feat: add company-based filter for accounts in Mint Bank Transaction Rule

### DIFF
--- a/mint/mint/doctype/mint_bank_transaction_rule/mint_bank_transaction_rule.js
+++ b/mint/mint/doctype/mint_bank_transaction_rule/mint_bank_transaction_rule.js
@@ -1,8 +1,14 @@
 // Copyright (c) 2025, The Commit Company (Algocode Technologies Pvt. Ltd.) and contributors
 // For license information, please see license.txt
 
-// frappe.ui.form.on("Mint Bank Transaction Rule", {
-// 	refresh(frm) {
-
-// 	},
-// });
+frappe.ui.form.on("Mint Bank Transaction Rule", {
+	company: function(frm) {
+		frm.set_query("account", function() {
+			return {
+				filters: {
+					company: frm.doc.company
+				}
+			};
+		});
+	},
+});


### PR DESCRIPTION
- Applied link filter on `accounts` field to show only accounts belonging to the selected company.

This will help us to avoid the below warning everytime. 
<img width="651" height="175" alt="Screenshot 2025-08-23 at 15 54 23" src="https://github.com/user-attachments/assets/b15f2778-1b6f-43d1-98b7-d2f7c1c9ce6f" />
