### PR TITLE
feat(ui): add searchable dropdown to CompanySelector

### DIFF
--- a/frontend/src/components/features/BankReconciliation/CompanySelector.tsx
+++ b/frontend/src/components/features/BankReconciliation/CompanySelector.tsx
@@ -1,12 +1,26 @@
 import { Button } from "@/components/ui/button"
-import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger } from "@/components/ui/dropdown-menu"
-import { Input } from "@/components/ui/input"
 import { selectedCompanyAtom, useCurrentCompany } from "@/hooks/useCurrentCompany"
 import { useSetAtom } from "jotai"
-import { Building2, ChevronDown, Search } from "lucide-react"
-import { useState, useMemo } from "react"
+import { Building2, Check, ChevronDown } from "lucide-react"
+import { useState } from "react"
+import {
+    Command,
+    CommandEmpty,
+    CommandGroup,
+    CommandInput,
+    CommandItem,
+    CommandList,
+} from "@/components/ui/command"
+import {
+    Popover,
+    PopoverContent,
+    PopoverTrigger,
+} from "@/components/ui/popover"
+import { cn } from "@/lib/utils"
+import _ from "@/lib/translate"
 
 const CompanySelector = () => {
+    const [open, setOpen] = useState(false)
     const [searchQuery, setSearchQuery] = useState("")
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -15,68 +29,53 @@ const CompanySelector = () => {
     const setSelectedCompany = useSetAtom(selectedCompanyAtom)
     const selectedCompany = useCurrentCompany()
 
-    // Filter options based on search query
-    const filteredOptions = useMemo(() => {
-        if (!searchQuery.trim()) return options
-        return options.filter((option: string) =>
-            option.toLowerCase().includes(searchQuery.toLowerCase())
-        )
-    }, [options, searchQuery])
-
-    // Show search input if there are more than 5 companies
-    const showSearch = options.length > 5
-
     const handleSelectCompany = (company: string) => {
         setSelectedCompany(company)
-        setSearchQuery("") 
+        setSearchQuery("")
+        setOpen(false)
     }
 
-    return (
-        <DropdownMenu onOpenChange={(open) => {
-            if (!open) setSearchQuery("") 
-        }}>
-            <DropdownMenuTrigger asChild>
-                <Button variant={'outline'}>
-                    <Building2 />
-                    {selectedCompany}
-                    <ChevronDown />
-                </Button>
-            </DropdownMenuTrigger>
-            <DropdownMenuContent align='start' className="w-64">
-                {showSearch && (
-                    <div className="p-2 border-b">
-                        <div className="relative">
-                            <Search className="absolute left-2 top-2.5 h-4 w-4 text-muted-foreground" />
-                            <Input
-                                placeholder="Search companies..."
-                                value={searchQuery}
-                                onChange={(e) => setSearchQuery(e.target.value)}
-                                className="pl-8 h-8"
-                                autoFocus
-                            />
-                        </div>
-                    </div>
-                )}
-                <div className="max-h-64 overflow-y-auto">
-                    {filteredOptions.length > 0 ? (
-                        filteredOptions.map((option: string) => (
-                            <DropdownMenuItem 
-                                key={option} 
-                                onClick={() => handleSelectCompany(option)}
-                                className="cursor-pointer"
+    return (<Popover open={open} onOpenChange={setOpen}>
+        <PopoverTrigger asChild>
+            <Button
+                variant="outline"
+                role="combobox"
+                aria-expanded={open}
+                className="justify-between"
+            >
+                <Building2 />
+                {selectedCompany}
+                <ChevronDown className="opacity-50" />
+            </Button>
+        </PopoverTrigger>
+        <PopoverContent className="min-w-56 w-fit p-0">
+            <Command>
+                {options.length > 5 && <CommandInput placeholder={_("Search company...")} className="h-9" />}
+                <CommandList>
+                    <CommandEmpty>{_("No company found.")}</CommandEmpty>
+                    <CommandGroup>
+                        {options.map((option: string) => (
+                            <CommandItem
+                                key={option}
+                                value={option}
+                                onSelect={(currentValue) => {
+                                    handleSelectCompany(currentValue)
+                                }}
                             >
                                 {option}
-                            </DropdownMenuItem>
-                        ))
-                    ) : (
-                        <div className="p-2 text-sm text-muted-foreground text-center">
-                            No companies found
-                        </div>
-                    )}
-                </div>
-            </DropdownMenuContent>
-        </DropdownMenu>
-    )
+                                <Check
+                                    className={cn(
+                                        "ml-auto",
+                                        searchQuery === option ? "opacity-100" : "opacity-0"
+                                    )}
+                                />
+                            </CommandItem>
+                        ))}
+                    </CommandGroup>
+                </CommandList>
+            </Command>
+        </PopoverContent>
+    </Popover>)
 }
 
 export default CompanySelector


### PR DESCRIPTION
Case scenario: WE have a client with over 20 companies.

- Added search input with icon inside dropdown when companies > 5
- Reset search query on dropdown close or company selection
- Improved UX with scrollable list and "No companies found" state
<img width="1272" height="645" alt="image (9)" src="https://github.com/user-attachments/assets/faebcf7f-d9bc-4937-86b9-3485076a4b9c" />
