### PR TITLE
feat: allow clearing transactions manually

### DIFF
--- a/frontend/src/components/features/BankReconciliation/BankClearanceSummary.tsx
+++ b/frontend/src/components/features/BankReconciliation/BankClearanceSummary.tsx
@@ -1,10 +1,10 @@
 import { useAtomValue } from "jotai"
 import { MissingFiltersBanner } from "./MissingFiltersBanner"
-import { bankRecDateAtom, selectedBankAccountAtom } from "./bankRecAtoms"
+import { bankRecDateAtom, SelectedBank, selectedBankAccountAtom } from "./bankRecAtoms"
 import { useCurrentCompany } from "@/hooks/useCurrentCompany"
 import { Paragraph } from "@/components/ui/typography"
-import { useMemo } from "react"
-import { useFrappeGetCall } from "frappe-react-sdk"
+import { useMemo, useState } from "react"
+import { useFrappeGetCall, useFrappePostCall } from "frappe-react-sdk"
 import { QueryReportReturnType } from "@/types/custom/Reports"
 import { formatDate } from "@/lib/date"
 import { Table, TableBody, TableCaption, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table"
@@ -19,6 +19,11 @@ import _ from "@/lib/translate"
 import { useCopyToClipboard } from "usehooks-ts"
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip"
 import { toast } from "sonner"
+import { Button } from "@/components/ui/button"
+import { Dialog, DialogClose, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle, DialogTrigger } from "@/components/ui/dialog"
+import { Form } from "@/components/ui/form"
+import { useForm } from "react-hook-form"
+import { DateField } from "@/components/ui/form-elements"
 
 const BankClearanceSummary = () => {
     const bankAccount = useAtomValue(selectedBankAccountAtom)
@@ -58,7 +63,7 @@ const BankClearanceSummaryView = () => {
         })
     }, [bankAccount, dates])
 
-    const { data, error } = useFrappeGetCall<{ message: QueryReportReturnType<BankClearanceSummaryEntry> }>('frappe.desk.query_report.run', {
+    const { data, error, mutate } = useFrappeGetCall<{ message: QueryReportReturnType<BankClearanceSummaryEntry> }>('frappe.desk.query_report.run', {
         report_name: 'Bank Clearance Summary',
         filters,
         ignore_prepared_report: 1,
@@ -126,9 +131,11 @@ const BankClearanceSummaryView = () => {
                             <TableCell>
                                 {row.clearance_date ? <Badge variant="outline" className="text-foreground px-1.5">
                                     <CheckCircle2 width={16} height={16} className="text-green-600 dark:text-green-500" />
-                                    {_("Cleared")}</Badge> : <Badge variant="destructive" className="bg-destructive/10 text-destructive">
-                                    <XCircle className="-mt-0.5 text-destructive" />
-                                    {_("Not Cleared")}</Badge>}
+                                    {_("Cleared")}</Badge> : <div className="flex items-center gap-2"><Badge variant="destructive" className="bg-destructive/10 text-destructive">
+                                        <XCircle className="-mt-0.5 text-destructive" />
+                                        {_("Not Cleared")}</Badge>
+                                    <SetClearanceDateButton voucher={row} bankAccount={bankAccount} companyID={companyID} mutate={mutate} />
+                                </div>}
                             </TableCell>
                         </TableRow>
                     ))}
@@ -147,6 +154,112 @@ const BankClearanceSummaryView = () => {
 
 
     </div>
+}
+
+const SetClearanceDateButton = ({ voucher, bankAccount, companyID, mutate }: { voucher: BankClearanceSummaryEntry, bankAccount: SelectedBank | null, companyID: string, mutate: VoidFunction }) => {
+
+    const [open, setOpen] = useState(false)
+
+    const onClose = () => {
+        setOpen(false)
+        mutate()
+    }
+
+    return <Dialog open={open} onOpenChange={setOpen}>
+        <DialogTrigger disabled={!bankAccount}>
+            <Tooltip delayDuration={500}>
+                <TooltipTrigger>
+                    <Button variant='link' size="sm" className="px-0 text-destructive underline underline-offset-4">{_("Force Clear")}</Button>
+                </TooltipTrigger>
+                <TooltipContent align='start'>
+                    {_("Set the clearance date for this voucher without reconciling with a bank transaction.")}
+                </TooltipContent>
+            </Tooltip>
+        </DialogTrigger>
+        <DialogContent className="min-w-2xl">
+            {bankAccount && <ForceClearVoucherForm voucher={voucher} bankAccount={bankAccount} companyID={companyID} onClose={onClose} />}
+        </DialogContent>
+    </Dialog>
+}
+
+const ForceClearVoucherForm = ({ voucher, bankAccount, companyID, onClose }: { voucher: BankClearanceSummaryEntry, bankAccount: SelectedBank, companyID: string, onClose: () => void }) => {
+
+    const form = useForm<{ clearance_date: string }>({
+        defaultValues: {
+            clearance_date: voucher.posting_date,
+        }
+    })
+
+    const { call, loading, error } = useFrappePostCall('mint.apis.bank_clearance.update_clearance_date')
+
+    const onSubmit = (data: { clearance_date: string }) => {
+        call({
+            payment_document: voucher.payment_document_type,
+            payment_entry: voucher.payment_entry,
+            account: bankAccount.account,
+            clearance_date: data.clearance_date,
+        })
+            .then(() => {
+                toast.success(_("Clearance date updated"))
+                onClose()
+            })
+    }
+
+    return <Form {...form}>
+        <form onSubmit={form.handleSubmit(onSubmit)}>
+
+            <div className='flex flex-col gap-4'>
+
+                <DialogHeader>
+                    <DialogTitle>{_("Force Clear Voucher")}</DialogTitle>
+                    <DialogDescription>
+                        {_("Set the clearance date for this voucher without reconciling with a bank transaction.")}
+                    </DialogDescription>
+                </DialogHeader>
+                {error && <ErrorBanner error={error} />}
+                <div>
+                    <Table>
+                        <TableHeader>
+                            <TableRow>
+                                <TableHead>{_("Payment Document")}</TableHead>
+                                <TableCell><a target="_blank" className="underline underline-offset-4"
+                                    href={`/app/${slug(voucher.payment_document_type)}/${voucher.payment_entry}`}>{_(voucher.payment_document_type)} : {voucher.payment_entry}</a></TableCell>
+                            </TableRow>
+                            <TableRow>
+                                <TableHead>{_("Posting Date")}</TableHead>
+                                <TableCell>{formatDate(voucher.posting_date)}</TableCell>
+                            </TableRow>
+                            <TableRow>
+                                <TableHead>{_("Cheque/Reference Number")}</TableHead>
+                                <TableCell title={voucher.cheque_no}>{voucher.cheque_no?.slice(0, 40)}{voucher.cheque_no?.length && voucher.cheque_no?.length > 40 ? "..." : ""}</TableCell>
+                            </TableRow>
+                            <TableRow>
+                                <TableHead>{_("Amount")}</TableHead>
+                                <TableCell className="text-right">{formatCurrency(voucher.amount, bankAccount?.account_currency ?? getCompanyCurrency(companyID))}</TableCell>
+                            </TableRow>
+                            <TableRow>
+                                <TableHead>{_("Against Account")}</TableHead>
+                                <TableCell><a target="_blank" className="underline underline-offset-4" href={`/app/account/${voucher.against}`}>{voucher.against}</a></TableCell>
+                            </TableRow>
+                        </TableHeader>
+                    </Table>
+                </div>
+                <DateField
+                    name='clearance_date'
+                    label={_("Clearance Date")}
+                    isRequired
+                    inputProps={{ autoFocus: true }}
+                />
+
+                <DialogFooter>
+                    <DialogClose asChild>
+                        <Button variant={'outline'} disabled={loading}>{_("Cancel")}</Button>
+                    </DialogClose>
+                    <Button type='submit' disabled={loading}>{_("Submit")}</Button>
+                </DialogFooter>
+            </div>
+        </form>
+    </Form>
 }
 
 export default BankClearanceSummary

--- a/mint/apis/bank_clearance.py
+++ b/mint/apis/bank_clearance.py
@@ -1,0 +1,26 @@
+import frappe
+
+@frappe.whitelist()
+def update_clearance_date(payment_document: str, payment_entry: str, account: str, clearance_date: str | None):
+    """
+    Update the clearance date of a voucher
+    """
+
+    if not clearance_date:
+        clearance_date = None
+
+    # Check for permissions
+    frappe.has_permission("Bank Clearance", ptype="write", throw=True)
+
+    if payment_document == "Sales Invoice":
+                frappe.db.set_value(
+                    "Sales Invoice Payment",
+                    {"parent": payment_entry, "account": account, "amount": [">", 0]},
+                    "clearance_date",
+                    clearance_date,
+                )
+
+    else:
+        frappe.db.set_value(
+            payment_document, payment_entry, "clearance_date", clearance_date
+        )


### PR DESCRIPTION
For transactions that are not cleared, you can now force set the clearance date. This is similar to using the Bank Clearance tool.

<img width="3128" height="1896" alt="CleanShot 2026-01-05 at 12 44 43@2x" src="https://github.com/user-attachments/assets/11259748-fbf0-4578-8fd0-b0d7faca3768" />
