### PR TITLE
fix(ux): consider filters when selecting next transaction on reconciliation

### DIFF
--- a/frontend/src/components/features/BankReconciliation/BankEntryModal.tsx
+++ b/frontend/src/components/features/BankReconciliation/BankEntryModal.tsx
@@ -401,8 +401,8 @@ const Entries = ({ company, isWithdrawal, amount, currency }: { company: string,
                                 label={_("Account")}
                                 rules={{
                                     required: _("Account is required"),
-                                    onChange: (value) => {
-                                        onAccountChange(value, index)
+                                    onChange: (event) => {
+                                        onAccountChange(event.target.value, index)
                                     }
                                 }}
                                 buttonClassName="min-w-64"
@@ -485,8 +485,8 @@ const PartyField = ({ index, onChange }: { index: number, onChange: (value: stri
         name={`entries.${index}.party`}
         label={_("Party")}
         rules={{
-            onChange: (value) => {
-                onChange(value, index)
+            onChange: (event) => {
+                onChange(event.target.value, index)
             }
         }}
         hideLabel

--- a/frontend/src/components/features/BankReconciliation/bankRecAtoms.ts
+++ b/frontend/src/components/features/BankReconciliation/bankRecAtoms.ts
@@ -36,3 +36,10 @@ export const bankRecRecordJournalEntryModalAtom = atom(false)
 export const bankRecUnreconcileModalAtom = atom<string>('')
 
 export const bankRecMatchFilters = atomWithStorage<string[]>('mint-bank-rec-match-filters', ['payment_entry', 'journal_entry'])
+
+export const bankRecSearchText = atom<string>('')
+export const bankRecAmountFilter = atom<{ value: number, stringValue?: string | number }>({
+    value: 0,
+    stringValue: '0.00'
+})
+export const bankRecTransactionTypeFilter = atom<string>('All')


### PR DESCRIPTION
Earlier: When a transaction was reconciled, the next "unreconciled" transaction was selected - even if there were filters applied which meant that the selected transaction was not visible on the screen - this was a little confusing.

Now, we only select the next transaction if it's visible. If the next transaction isn't there in the updated transaction list, we do not select anything.