### PR TITLE
fix: use absolute value for total allocated amount

### DIFF
--- a/frontend/src/hooks/usePaymentEntryCalculations.tsx
+++ b/frontend/src/hooks/usePaymentEntryCalculations.tsx
@@ -124,8 +124,8 @@ export const usePaymentEntryCalculations = () => {
                 base_total_allocated_amount += flt(ref.allocated_amount)
             }
         })
-        setValue('total_allocated_amount', total_allocated_amount)
-        setValue('base_total_allocated_amount', base_total_allocated_amount)
+        setValue('total_allocated_amount', Math.abs(total_allocated_amount))
+        setValue('base_total_allocated_amount', Math.abs(base_total_allocated_amount))
         setUnallocatedAmount()
     }, [getValues, setValue, setUnallocatedAmount])
 


### PR DESCRIPTION
ERPNext sets the absolute value instead of negatives. Fixed this.

Closes #36 