### PR TITLE
fix: refresh balance on force clearing transaction

### DIFF
--- a/frontend/src/components/features/BankReconciliation/BankClearanceSummary.tsx
+++ b/frontend/src/components/features/BankReconciliation/BankClearanceSummary.tsx
@@ -205,8 +205,6 @@ const ForceClearVoucherForm = ({ voucher, bankAccount, companyID, onClose }: { v
             .then(() => {
                 toast.success(_("Clearance date updated"))
                 onClose()
-
-                mutate(`bank-reconciliation-unreconciled-transactions-${bankAccount?.name}-${dates.fromDate}-${dates.toDate}`)
                 mutate(`bank-reconciliation-account-closing-balance-${bankAccount?.name}-${dates.toDate}`)
             })
     }


### PR DESCRIPTION
Related to #83  - force clearing a transaction should also update the closing balance on the top of the screen.