### PR TITLE
feat(ux): add keyboard shortcuts

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -52,6 +52,7 @@
     "react-day-picker": "^9.8.1",
     "react-dom": "^19.1.1",
     "react-hook-form": "^7.61.1",
+    "react-hotkeys-hook": "^5.2.1",
     "react-markdown": "^10.1.0",
     "react-virtuoso": "^4.13.0",
     "rehype-raw": "^7.0.0",

--- a/frontend/src/components/features/BankReconciliation/MatchAndReconcile.tsx
+++ b/frontend/src/components/features/BankReconciliation/MatchAndReconcile.tsx
@@ -29,6 +29,9 @@ import RecordPaymentModal from "./RecordPaymentModal"
 import { Card, CardAction, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import SelectedTransactionsTable from "./SelectedTransactionsTable"
 import MatchFilters from "./MatchFilters"
+import { useHotkeys } from "react-hotkeys-hook"
+import { KeyboardMetaKeyIcon } from "@/components/ui/keyboard-keys"
+import { Kbd, KbdGroup } from "@/components/ui/kbd"
 
 const MatchAndReconcile = ({ contentHeight }: { contentHeight: number }) => {
     const selectedBank = useAtomValue(selectedBankAccountAtom)
@@ -266,11 +269,48 @@ const VouchersSection = ({ contentHeight }: { contentHeight: number }) => {
     </div>
 }
 
-const OptionsForMultipleTransactions = ({ transactions }: { transactions: UnreconciledTransaction[] }) => {
-
+const useKeyboardShortcuts = () => {
     const setTransferModalOpen = useSetAtom(bankRecTransferModalAtom)
     const setRecordPaymentModalOpen = useSetAtom(bankRecRecordPaymentModalAtom)
     const setRecordJournalEntryModalOpen = useSetAtom(bankRecRecordJournalEntryModalAtom)
+
+    useHotkeys('meta+p', () => {
+        // 
+        setRecordPaymentModalOpen(true)
+    }, {
+        enabled: true,
+        enableOnFormTags: false,
+        preventDefault: true
+    })
+
+    useHotkeys('meta+b', () => {
+        // 
+        setRecordJournalEntryModalOpen(true)
+    }, {
+        enabled: true,
+        enableOnFormTags: false,
+        preventDefault: true
+    })
+
+    useHotkeys('meta+i', () => {
+        // 
+        setTransferModalOpen(true)
+    }, {
+        enabled: true,
+        enableOnFormTags: false,
+        preventDefault: true
+    })
+
+    return {
+        setTransferModalOpen,
+        setRecordPaymentModalOpen,
+        setRecordJournalEntryModalOpen
+    }
+}
+
+const OptionsForMultipleTransactions = ({ transactions }: { transactions: UnreconciledTransaction[] }) => {
+
+    const { setTransferModalOpen, setRecordPaymentModalOpen, setRecordJournalEntryModalOpen } = useKeyboardShortcuts()
 
     return <div className="flex flex-col py-4">
         <Card className="gap-2">
@@ -285,7 +325,6 @@ const OptionsForMultipleTransactions = ({ transactions }: { transactions: Unreco
                 </CardTitle>
             </CardHeader>
             <CardContent>
-
                 <SelectedTransactionsTable />
 
                 <CardAction className="mt-4">
@@ -304,6 +343,10 @@ const OptionsForMultipleTransactions = ({ transactions }: { transactions: Unreco
                                     </TooltipTrigger>
                                     <TooltipContent>
                                         {_("Record a journal entry for expenses, income or split transactions")}
+                                        <KbdGroup className="ml-2">
+                                            <Kbd><KeyboardMetaKeyIcon /></Kbd>
+                                            <Kbd>B</Kbd>
+                                        </KbdGroup>
                                     </TooltipContent>
                                 </Tooltip>
                                 <Tooltip>
@@ -318,6 +361,10 @@ const OptionsForMultipleTransactions = ({ transactions }: { transactions: Unreco
                                     </TooltipTrigger>
                                     <TooltipContent>
                                         {_("Record a payment entry against a customer or supplier")}
+                                        <KbdGroup className="ml-2">
+                                            <Kbd><KeyboardMetaKeyIcon /></Kbd>
+                                            <Kbd>P</Kbd>
+                                        </KbdGroup>
                                     </TooltipContent>
                                 </Tooltip>
 
@@ -333,6 +380,10 @@ const OptionsForMultipleTransactions = ({ transactions }: { transactions: Unreco
                                     </TooltipTrigger>
                                     <TooltipContent>
                                         {_("Record an internal transfer to another bank/credit card/cash account")}
+                                        <KbdGroup className="ml-2">
+                                            <Kbd><KeyboardMetaKeyIcon /></Kbd>
+                                            <Kbd>I</Kbd>
+                                        </KbdGroup>
                                     </TooltipContent>
                                 </Tooltip>
 
@@ -349,9 +400,7 @@ const OptionsForMultipleTransactions = ({ transactions }: { transactions: Unreco
 
 const OptionsForSingleTransaction = ({ transaction, contentHeight }: { transaction: UnreconciledTransaction, contentHeight: number }) => {
 
-    const setTransferModalOpen = useSetAtom(bankRecTransferModalAtom)
-    const setRecordPaymentModalOpen = useSetAtom(bankRecRecordPaymentModalAtom)
-    const setRecordJournalEntryModalOpen = useSetAtom(bankRecRecordJournalEntryModalAtom)
+    const { setTransferModalOpen, setRecordPaymentModalOpen, setRecordJournalEntryModalOpen } = useKeyboardShortcuts()
 
     return <div className="flex flex-col gap-3">
         <TooltipProvider>
@@ -368,6 +417,10 @@ const OptionsForSingleTransaction = ({ transaction, contentHeight }: { transacti
                         </TooltipTrigger>
                         <TooltipContent>
                             {_("Record a payment entry against a customer or supplier")}
+                            <KbdGroup className="ml-2">
+                                <Kbd><KeyboardMetaKeyIcon /></Kbd>
+                                <Kbd>P</Kbd>
+                            </KbdGroup>
                         </TooltipContent>
                     </Tooltip>
                     <Tooltip>
@@ -381,6 +434,10 @@ const OptionsForSingleTransaction = ({ transaction, contentHeight }: { transacti
                         </TooltipTrigger>
                         <TooltipContent>
                             {_("Record a journal entry for expenses, income or split transactions")}
+                            <KbdGroup className="ml-2">
+                                <Kbd><KeyboardMetaKeyIcon /></Kbd>
+                                <Kbd>B</Kbd>
+                            </KbdGroup>
                         </TooltipContent>
                     </Tooltip>
                     <Tooltip >
@@ -394,6 +451,10 @@ const OptionsForSingleTransaction = ({ transaction, contentHeight }: { transacti
                         </TooltipTrigger>
                         <TooltipContent>
                             {_("Record an internal transfer to another bank/credit card/cash account")}
+                            <KbdGroup className="ml-2">
+                                <Kbd><KeyboardMetaKeyIcon /></Kbd>
+                                <Kbd>I</Kbd>
+                            </KbdGroup>
                         </TooltipContent>
                     </Tooltip>
                 </div>

--- a/frontend/src/components/ui/kbd.tsx
+++ b/frontend/src/components/ui/kbd.tsx
@@ -1,0 +1,28 @@
+import { cn } from "@/lib/utils"
+
+function Kbd({ className, ...props }: React.ComponentProps<"kbd">) {
+    return (
+        <kbd
+            data-slot="kbd"
+            className={cn(
+                "bg-muted text-muted-foreground pointer-events-none inline-flex h-5 w-fit min-w-5 items-center justify-center gap-1 rounded-sm px-1 font-mono text-xs font-medium select-none",
+                "[&_svg:not([class*='size-'])]:size-3",
+                "[[data-slot=tooltip-content]_&]:bg-background/20 [[data-slot=tooltip-content]_&]:text-background dark:[[data-slot=tooltip-content]_&]:bg-background/10",
+                className
+            )}
+            {...props}
+        />
+    )
+}
+
+function KbdGroup({ className, ...props }: React.ComponentProps<"div">) {
+    return (
+        <kbd
+            data-slot="kbd-group"
+            className={cn("inline-flex items-center gap-1", className)}
+            {...props}
+        />
+    )
+}
+
+export { Kbd, KbdGroup }

--- a/frontend/src/components/ui/keyboard-keys.tsx
+++ b/frontend/src/components/ui/keyboard-keys.tsx
@@ -1,0 +1,8 @@
+
+export const KeyboardMetaKeyIcon = () => {
+    if (navigator.platform.toUpperCase().indexOf('MAC') >= 0) {
+        return <span className="text-sm">⌘</span>
+    } else {
+        return <span>Ctrl</span>
+    }
+}

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -3438,6 +3438,11 @@ react-hook-form@^7.61.1:
   resolved "https://registry.yarnpkg.com/react-hook-form/-/react-hook-form-7.61.1.tgz#8c1f086ccd921a6e90df6800787e9ca3833f86c1"
   integrity sha512-2vbXUFDYgqEgM2RcXcAT2PwDW/80QARi+PKmHy5q2KhuKvOlG8iIYgf7eIlIANR5trW9fJbP4r5aub3a4egsew==
 
+react-hotkeys-hook@^5.2.1:
+  version "5.2.1"
+  resolved "https://registry.yarnpkg.com/react-hotkeys-hook/-/react-hotkeys-hook-5.2.1.tgz#a47ff1105057bf06de079624ec582a6d124be48e"
+  integrity sha512-xbKh6zJxd/vJHT4Bw4+0pBD662Fk20V+VFhLqciCg+manTVO4qlqRqiwFOYelfHN9dBvWj9vxaPkSS26ZSIJGg==
+
 react-markdown@^10.1.0:
   version "10.1.0"
   resolved "https://registry.yarnpkg.com/react-markdown/-/react-markdown-10.1.0.tgz#e22bc20faddbc07605c15284255653c0f3bad5ca"


### PR DESCRIPTION
`Ctrl + P` - for payment entry
`Ctrl + B` - for Bank Entry (JE)
`Ctrl + I` - for transfer - didn't want to use T since that's for opening a new tab.

<img width="3134" height="1886" alt="CleanShot 2026-01-09 at 15 32 19@2x" src="https://github.com/user-attachments/assets/90a81cad-ae7f-4dcd-9a50-d3e418e18e43" />
