### PR TITLE
fix: correct credit and debit assignment in `create_bulk_bank_entry_and_reconcile function`

### DIFF
--- a/mint/apis/bank_reconciliation.py
+++ b/mint/apis/bank_reconciliation.py
@@ -248,7 +248,7 @@ def create_bulk_bank_entry_and_reconcile(bank_transactions: list[str|int],
                 "debit_in_account_currency": transactions_details.unallocated_amount,
                 "debit": transactions_details.unallocated_amount,
                 "credit_in_account_currency": 0,
-                "debit": 0,
+                "credit": 0,
             })
 
             entries.append({


### PR DESCRIPTION
Looks like a typo error